### PR TITLE
version: fix script

### DIFF
--- a/version.sh
+++ b/version.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -e
-
 version_file=`dirname $0`/VERSION
 
 if [ -f $version_file ]; then
@@ -9,11 +7,8 @@ if [ -f $version_file ]; then
     exit 0
 fi
 
-set +e
-current_tag=`git describe --tags 2> /dev/null`
-set -e
-
-if git tag -l | grep "^$current_tag\$"; then
+current_tag=`git describe --tags --exact-match 2> /dev/null`
+if [ $? -eq 0 ]; then
     echo $current_tag
 else
     git branch | grep '^\*' | awk '{ print $2}'


### PR DESCRIPTION
When a tag is set the script echoed the tag twice with a newline inserted, breaking the `make build` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigonode/288)
<!-- Reviewable:end -->
