### PR TITLE
Docker: improve existing and add dev image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM stratumn/gobase:0.3.0
+FROM stratumn/gobase:latest
 
 RUN addgroup -S -g 999 indigo-node
 RUN adduser -H -D -u 999 -G indigo-node indigo-node
@@ -18,8 +18,7 @@ USER indigo-node
 
 WORKDIR /usr/local/var/indigo-node
 
-ENTRYPOINT [ "/usr/local/bin/indigo-node" ]
-
 EXPOSE 8903 8904 8905 8906
-
 VOLUME [ "/usr/local/etc/indigo-node", "/usr/local/var/indigo-node" ]
+
+ENTRYPOINT [ "/usr/local/bin/indigo-node", "--core-config", "/usr/local/etc/indigo-node/indigo_node.core.toml", "--cli-config", "/usr/local/etc/indigo-node/indigo_node.cli.toml" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,21 @@
+FROM golang:1.10.3-alpine3.8
+
+RUN apk add --no-cache git
+RUN apk add --no-cache make
+RUN apk add --no-cache bash
+RUN apk add --no-cache gcc
+RUN apk add --no-cache musl-dev
+
+RUN mkdir -p /go/src/github.com/stratumn
+WORKDIR /go/src/github.com/stratumn
+
+RUN git clone https://github.com/stratumn/go-indigonode
+WORKDIR /go/src/github.com/stratumn/go-indigonode
+
+RUN make deps
+RUN make install
+
+EXPOSE 8903 8904 8905 8906
+VOLUME [ "/go/src/github.com/stratumn/go-indigonode" ]
+
+ENTRYPOINT ["indigo-node"]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DIST_DIR=dist
 RELEASE_NAME=$(GIT_TAG)
 RELEASE_NOTES_FILE=RELEASE_NOTES.md
 TEXT_FILES=LICENSE RELEASE_NOTES.md CHANGE_LOG.md
-DOCKER_USER=$(GITHUB_USER)
+DOCKER_USER=indigocore
 DOCKER_FILE=Dockerfile
 COVERAGE_FILE=coverage.txt
 COVERHTML_FILE=coverhtml.txt
@@ -301,12 +301,11 @@ github_publish:
 
 # == docker_image =============================================================
 docker_image: $(DOCKER_EXEC)
-	$(DOCKER_BUILD) -f $(DOCKER_FILE) -t $(DOCKER_USER)/$(CMD):$(VERSION) -t $(DOCKER_USER)/$(CMD):latest .
+	$(DOCKER_BUILD) -f $(DOCKER_FILE) -t $(DOCKER_USER)/$(CMD):$(VERSION) .
 
 # == docker_push ==============================================================
 docker_push:
 	$(DOCKER_PUSH) $(DOCKER_USER)/$(CMD):$(VERSION)
-	$(DOCKER_PUSH) $(DOCKER_USER)/$(CMD):latest
 
 # == license_headers ==========================================================
 license_headers:


### PR DESCRIPTION
I setup an automated build on the master branch on Docker hub. It uses the Dockerfile.dev build.
The make command to create and push a docker image should only push the image tagged with the relevant version, not the latest (which will be a dev image).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/go-indigonode/289)
<!-- Reviewable:end -->
